### PR TITLE
fix: unwind aggregate counts for array types (layer category) [EP-2391]

### DIFF
--- a/scripts/bootstrap-fixture-data.ts
+++ b/scripts/bootstrap-fixture-data.ts
@@ -41,7 +41,7 @@ const processLine = async (line: string): Promise<void> => {
 
   const location: Location = {
     id: data['id'] || uuidv4(),
-    slug: data['slug'] || slugifyName(data['name']),
+    slug: slugifyName(data['name']),
     name: cleanStr(data['name']),
     type: <LocationTypeEnum>splitPascalCase(data['type']),
     description: cleanStr(data['description']),

--- a/src/models/utils/index.ts
+++ b/src/models/utils/index.ts
@@ -280,14 +280,14 @@ export const aggregateCount = async <T extends Document, L extends keyof T>(
 ): Promise<AggCount[]> => {
   const result = await model
     .aggregate([
+      // filter docs to match the specified condition(s);
       { $match: omit(query, [field]) },
+      // pass docs to next stage in the pipeline;
       { $project: { [field]: true } },
-      {
-        $group: {
-          _id: '$' + field,
-          count: { $sum: 1 },
-        },
-      },
+      // deconstructs an array field to output a document for each element;
+      { $unwind: '$' + field },
+      // group by the specified _id expression and output a document for each distinct grouping;
+      { $group: { _id: '$' + field, count: { $sum: 1 } } },
     ])
     .exec();
 


### PR DESCRIPTION
Unwind filter aggregate counts for array type fields (multiple-select, such as layer category).

Before:
<img width="399" alt="Screenshot 2020-08-05 at 15 04 06" src="https://user-images.githubusercontent.com/9037628/89411377-fc066880-d72d-11ea-9f86-50ca1e9a9393.png">

After:
<img width="399" alt="Screenshot 2020-08-05 at 15 04 06" src="https://user-images.githubusercontent.com/9037628/89411138-96b27780-d72d-11ea-967c-124ccb7a6665.png">
