### PR TITLE
fix: Add standalone bulk response serializer

### DIFF
--- a/src/routers/UserRouter.ts
+++ b/src/routers/UserRouter.ts
@@ -495,7 +495,7 @@ const getAdminRouter = (basePath: string = '/', routePath: string = '/management
       });
 
       if (data.some((res) => ![200, 409].includes(res.status))) {
-        const code = 403;
+        const code = 400;
         const response = createUserBulkSerializer().serialize(data);
 
         res.setHeader('Content-Type', DEFAULT_CONTENT_TYPE);

--- a/src/serializers/UserSerializer.ts
+++ b/src/serializers/UserSerializer.ts
@@ -24,6 +24,7 @@ import { PaginationLinks } from '.';
 export const USER_ATTRIBUTES: string[] = ['id', 'email', 'name', 'groups', 'firstName', 'lastName', 'pendingEmail'];
 export const GROUP_ATTRIBUTES: string[] = ['id', 'name', 'description', 'roles'];
 export const ROLE_ATTRIBUTES: string[] = ['id', 'name', 'description'];
+export const USER_BULK_ATTRIBUTES: string[] = ['email', 'error', 'status'];
 
 export const createSerializer = (
   include: string[] = [],
@@ -57,6 +58,24 @@ export const createSerializer = (
       attributes: GROUP_ATTRIBUTES,
       pluralizeType: false,
     },
+    topLevelLinks: pagination,
+    meta: meta,
+    ...opts,
+  } as any);
+};
+
+export const createBulkSerializer = (
+  include: string[] = [],
+  pagination: PaginationLinks = {},
+  meta: any = {},
+  opts: SerializerOptions = {}
+): Serializer => {
+  return new Serializer('bulkUser', {
+    attributes: USER_BULK_ATTRIBUTES,
+    keyForAttribute: (attribute: any) => {
+      return attribute;
+    },
+    pluralizeType: false,
     topLevelLinks: pagination,
     meta: meta,
     ...opts,


### PR DESCRIPTION
Changes:
- change response output to support (multiple) status codes instead of boolean flags;
- make response JSONAPI spec compatible;

Sample response:
- status: 409 (non-blocking)
- status: 404 (blocking, changes required)
- status 200 (success)

```
{
  "links": {},
  "meta": {},
  "data": [
    {
      "type": "bulkUser",
      "attributes": {
        "email": "hiacos_c@ngs.org",
        "error": "The user already exists.",
        "status": 409
      }
    },
    {
      "type": "bulkUser",
      "attributes": {
        "email": "hiacos_c+random@ngs.org",
        "error": "User not found for email: hiacos_c+random@ngs.org",
        "status": 404
      }
    },
    {
      "type": "bulkUser",
      "attributes": {
        "email": "hiacos_c+viewer1@ngs.org",
        "status": 200
      }
    }
  ]
}
```
